### PR TITLE
Legend menu control to map wind speed to color

### DIFF
--- a/src/layers/flow-layer.js
+++ b/src/layers/flow-layer.js
@@ -20,7 +20,20 @@ let FlowLayer = ForecastLayer.extend({
       minVelocity: 3,           // used to align color scale
       maxVelocity: 20,          // used to align color scale
       velocityScale: 0.01,     // modifier for particle animations, arbitrarily defaults to 0.005
-      colorScale: null,
+      colorScale: [
+        "rgb(36,104, 180)",
+        "rgb(60,157, 194)",
+        "rgb(128,205,193 )",
+        "rgb(151,218,168 )",
+        "rgb(252,217,125)",
+        "rgb(255,182,100)",
+        "rgb(252,150,75)",
+        "rgb(250,112,52)",
+        "rgb(245,64,32)",
+        "rgb(237,45,28)",
+        "rgb(220,24,32)",
+        "rgb(180,0,35)"
+      ],
       data: null                // data will be requested on-demand
     }, options)
     let layer = L.velocityLayer(layerOptions)

--- a/src/mixins/map/index.js
+++ b/src/mixins/map/index.js
@@ -6,6 +6,7 @@ import fileLayers from './mixin.file-layers'
 import fullscreen from './mixin.fullscreen'
 import measure from './mixin.measure'
 import scalebar from './mixin.scalebar'
+import legend from './mixin.legend'
 
 export default {
   base,
@@ -15,5 +16,6 @@ export default {
   fileLayers,
   fullscreen,
   measure,
-  scalebar
+  scalebar,
+  legend
 }

--- a/src/mixins/map/mixin.base.js
+++ b/src/mixins/map/mixin.base.js
@@ -2,7 +2,6 @@ import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 import store from '../store'
 
-import { FlowLayer } from '../../layers/flow-layer'
 // Fix to make Leaflet assets be correctly inserted by webpack
 delete L.Icon.Default.prototype._getIconUrl
 L.Icon.Default.mergeOptions({
@@ -13,54 +12,8 @@ L.Icon.Default.mergeOptions({
 
 let baseMixin = {
   methods: {
-    setUpLegend(){ //set up legend menu to map speed with color
-        this.controls.forEach(control => {if(control.options.controlButton && control.options.controlButton.title == 'Legend'){
-        let FlowLayerObj = new FlowLayer()
-        let colors = FlowLayerObj._baseLayer.options.colorScale
-        let min = FlowLayerObj._baseLayer.options.minVelocity
-        let max = FlowLayerObj._baseLayer.options.maxVelocity
-        let colorIndexForSpeed =[]
-        colors.indexFor = function (m) {  // map velocity speed to a style
-          return Math.max(0, Math.min((colors.length - 1),
-            Math.round((m - min) / (max - min) * (colors.length - 1))));
-        }
-         for(let j=0; j<=max; j++){
-           colorIndexForSpeed.push(colors.indexFor(j))
-         }
-        let mpsToKnot = function(mps){
-          return mps*1.94384
-        }
-          let labelsForMps = ['<span style="text-align:center; width: 30px; height: 18px; float: left; margin-right: 8px; opacity: 0.7; background: white">MPS</span> ']
-          let labelsForKnot = ['<span style="text-align:center; width: 30px; height: 18px; float: left; margin-right: 8px; opacity: 0.7; background:white">KT</span> ']
-          for (var i = 0; i < colors.length; i++) {
-            labelsForMps.push(
-              '<span style="text-align:center; width: 30px; height: 18px; float: left; margin-right: 8px; opacity: 0.7; background:' + colors[i]+ '">'+ colorIndexForSpeed.indexOf(i) +'</span> '
-            )
-            labelsForKnot.push(
-              '<span style="text-align:center; width: 30px; height: 18px; float: left; margin-right: 8px; opacity: 0.7; background:' + colors[i]+ '">'+ (mpsToKnot(colorIndexForSpeed.indexOf(i))).toFixed(0) +'</span> '
-            )
-          }
-          let flag = 0
-          let Mps ='<div title="Click to convert speed from Mps to Knot" style="position:absolute; cursor:pointer;">'+ labelsForMps.join('<br>') +'</div>'
-          let Knot ='<div title="Click to convert speed from Knot to Mps" style="position:absolute; cursor:pointer;">'+ labelsForKnot.join('<br>') +'</div>'
-          control._container.classList.remove('legend-container')
-          control._container.innerHTML = Knot
-          control._container.addEventListener('click',function(e){
-              if(flag==0)
-                {
-                  control._container.innerHTML=Mps
-                  flag=1
-                }
-              else{
-                control._container.innerHTML=Knot
-                  flag=0
-              }
-          })
-      }})
-    },
     setupControls () {
       this.controls.forEach(control => control.addTo(this.map))
-      this.setUpLegend()
       this.$emit('controlsReady')
     },
     center (longitude, latitude, zoomLevel) {

--- a/src/mixins/map/mixin.base.js
+++ b/src/mixins/map/mixin.base.js
@@ -1,6 +1,8 @@
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 import store from '../store'
+
+import { FlowLayer } from '../../layers/flow-layer'
 // Fix to make Leaflet assets be correctly inserted by webpack
 delete L.Icon.Default.prototype._getIconUrl
 L.Icon.Default.mergeOptions({
@@ -11,8 +13,54 @@ L.Icon.Default.mergeOptions({
 
 let baseMixin = {
   methods: {
+    setUpLegend(){ //set up legend menu to map speed with color
+        this.controls.forEach(control => {if(control.options.controlButton && control.options.controlButton.title == 'Legend'){
+        let FlowLayerObj = new FlowLayer()
+        let colors = FlowLayerObj._baseLayer.options.colorScale
+        let min = FlowLayerObj._baseLayer.options.minVelocity
+        let max = FlowLayerObj._baseLayer.options.maxVelocity
+        let colorIndexForSpeed =[]
+        colors.indexFor = function (m) {  // map velocity speed to a style
+          return Math.max(0, Math.min((colors.length - 1),
+            Math.round((m - min) / (max - min) * (colors.length - 1))));
+        }
+         for(let j=0; j<=max; j++){
+           colorIndexForSpeed.push(colors.indexFor(j))
+         }
+        let mpsToKnot = function(mps){
+          return mps*1.94384
+        }
+          let labelsForMps = ['<span style="text-align:center; width: 30px; height: 18px; float: left; margin-right: 8px; opacity: 0.7; background: white">MPS</span> ']
+          let labelsForKnot = ['<span style="text-align:center; width: 30px; height: 18px; float: left; margin-right: 8px; opacity: 0.7; background:white">KT</span> ']
+          for (var i = 0; i < colors.length; i++) {
+            labelsForMps.push(
+              '<span style="text-align:center; width: 30px; height: 18px; float: left; margin-right: 8px; opacity: 0.7; background:' + colors[i]+ '">'+ colorIndexForSpeed.indexOf(i) +'</span> '
+            )
+            labelsForKnot.push(
+              '<span style="text-align:center; width: 30px; height: 18px; float: left; margin-right: 8px; opacity: 0.7; background:' + colors[i]+ '">'+ (mpsToKnot(colorIndexForSpeed.indexOf(i))).toFixed(0) +'</span> '
+            )
+          }
+          let flag = 0
+          let Mps ='<div title="Click to convert speed from Mps to Knot" style="position:absolute; cursor:pointer;">'+ labelsForMps.join('<br>') +'</div>'
+          let Knot ='<div title="Click to convert speed from Knot to Mps" style="position:absolute; cursor:pointer;">'+ labelsForKnot.join('<br>') +'</div>'
+          control._container.classList.remove('legend-container')
+          control._container.innerHTML = Knot
+          control._container.addEventListener('click',function(e){
+              if(flag==0)
+                {
+                  control._container.innerHTML=Mps
+                  flag=1
+                }
+              else{
+                control._container.innerHTML=Knot
+                  flag=0
+              }
+          })
+      }})
+    },
     setupControls () {
       this.controls.forEach(control => control.addTo(this.map))
+      this.setUpLegend()
       this.$emit('controlsReady')
     },
     center (longitude, latitude, zoomLevel) {

--- a/src/mixins/map/mixin.legend.js
+++ b/src/mixins/map/mixin.legend.js
@@ -1,0 +1,22 @@
+import L from 'leaflet'
+import 'leaflet-legend/leaflet-legend.js'
+import 'leaflet-legend/leaflet-legend.css'
+
+import store from '../store'
+
+let legendMixin = {
+  mounted () {
+    let legendControl = new L.Control.Legend({ 
+        position: 'topleft',
+        collapsed: true,
+        controlButton: {
+            title: "Legend"
+        }
+     })
+    this.controls.push(legendControl)
+  }
+}
+
+store.set('legend', legendMixin)
+
+export default legendMixin

--- a/src/mixins/map/mixin.legend.js
+++ b/src/mixins/map/mixin.legend.js
@@ -1,10 +1,50 @@
 import L from 'leaflet'
 import 'leaflet-legend/leaflet-legend.js'
 import 'leaflet-legend/leaflet-legend.css'
-
 import store from '../store'
 
 let legendMixin = {
+   methods: {
+    setUpLegend(colors,min,max){ //set up legend menu to map speed with color
+        this.controls.forEach(control => {if(control.options.controlButton && control.options.controlButton.title == 'Legend'){
+        let colorIndexForSpeed =[]
+        colors.indexFor = function (m) {  // map velocity speed to a style
+          return Math.max(0, Math.min((colors.length - 1),
+          Math.round((m - min) / (max - min) * (colors.length - 1))));
+        }
+        for(let j=0; j<=max; j++){
+          colorIndexForSpeed.push(colors.indexFor(j))
+        }        
+        let mpsToKnot = function(mps){
+          return mps*1.94384
+        }
+        let labelsForMps = ['<span style="text-align:center; width: 30px; height: 18px; float: left; margin-right: 8px; opacity: 0.7; background: white">MPS</span> ']
+        let labelsForKnot = ['<span style="text-align:center; width: 30px; height: 18px; float: left; margin-right: 8px; opacity: 0.7; background:white">KT</span> ']
+        for (var i = 0; i < colors.length; i++) {
+          labelsForMps.push(
+            '<span style="text-align:center; width: 30px; height: 18px; float: left; margin-right: 8px; opacity: 0.7; background:' + colors[i]+ '">'+ colorIndexForSpeed.indexOf(i) +'</span> '
+          )
+        labelsForKnot.push('<span style="text-align:center; width: 30px; height: 18px; float: left; margin-right: 8px; opacity: 0.7; background:' + colors[i]+ '">'+ (mpsToKnot(colorIndexForSpeed.indexOf(i))).toFixed(0) +'</span> ')
+         }
+        let flag = 0
+        let Mps ='<div title="Click to convert speed from Mps to Knot" style="position:absolute; cursor:pointer;">'+ labelsForMps.join('<br>') +'</div>'
+        let Knot ='<div title="Click to convert speed from Knot to Mps" style="position:absolute; cursor:pointer;">'+ labelsForKnot.join('<br>') +'</div>'
+        control._container.classList.remove('legend-container')
+        control._container.innerHTML = Knot
+        control._container.addEventListener('click',function(e){
+          if(flag==0)
+            {
+              control._container.innerHTML = Mps
+              flag=1
+            }
+          else{
+            control._container.innerHTML = Knot
+            flag=0
+          }
+        })
+       }})
+     }
+  },
   mounted () {
     let legendControl = new L.Control.Legend({ 
         position: 'topleft',
@@ -13,7 +53,17 @@ let legendMixin = {
             title: "Legend"
         }
      })
-    this.controls.push(legendControl)
+    this.controls.push(legendControl)          
+    this.map.on('layeradd', event => {
+      if(event.layer._baseLayer){
+        let colors = event.layer._baseLayer.options.colorScale
+        let min = event.layer._baseLayer.options.minVelocity
+        let max = event.layer._baseLayer.options.maxVelocity
+        if(colors && min && max){
+        this.setUpLegend(colors,min,max)
+        }
+      }
+    })
   }
 }
 


### PR DESCRIPTION
### Summary of functionality
- This fork of weacast-client includes functionality of a legend-menu added as a leaflet control.
- Color-gradient used for defining colors used to display wind has been changed from the original.
- This legend menu displays all colors defined in the color gradient, and mentions on them the wind 
   speed at which the color to display wind is changed from one color to another.
- This mapping is done for speed in knots as well as in m/s with an on-click functionality on the legend 
   to switch between the two.

### Dependency
- For this a legend mixin file is created which uses an external module [leaflet-legend](https://github.com/mikeskaug/Leaflet.Legend) version 1.0.2 to provide a legend control.
- This module is to be added in package.json file at root directory, and the config file for the project 
  needs to include 'legend' mixin in the array of mixins defined.



